### PR TITLE
Fix plugin activation upon installation

### DIFF
--- a/wp-plugin/bookgpt-wp.php
+++ b/wp-plugin/bookgpt-wp.php
@@ -181,5 +181,11 @@ function bookgpt_create_db_tables() {
 }
 register_activation_hook(__FILE__, 'bookgpt_create_db_tables');
 
+// Ensure the plugin activates automatically upon installation
+activate_plugin(plugin_basename(__FILE__));
+
+// Ensure the plugin deactivates correctly
+deactivate_plugins(plugin_basename(__FILE__));
+
 // Initialize the plugin
 run_bookgpt();


### PR DESCRIPTION
Add code to activate and deactivate the plugin automatically upon installation.

* **Activation**: Add a call to `activate_plugin` function in `wp-plugin/bookgpt-wp.php` to ensure the plugin activates automatically upon installation.
* **Deactivation**: Add a call to `deactivate_plugins` function in `wp-plugin/bookgpt-wp.php` to ensure the plugin deactivates correctly.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shuddl/bookgpt/pull/7?shareId=5ec9618a-bc0c-4e7e-ba6c-abc9bbaa7865).