### PR TITLE
Fix missing hmac import in backend

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,3 +1,4 @@
+import hmac
 from fastapi import FastAPI, Request, HTTPException
 import uvicorn
 from pydantic import BaseModel


### PR DESCRIPTION
Add the import statement for the `hmac` module at the top of `backend/main.py`.

* Import the `hmac` module at the top of the file to ensure it is available for use in verifying webhook signatures.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shuddl/bookgpt/pull/11?shareId=7ab0e50d-0ee9-4b46-858c-6da093a65870).