### PR TITLE
Fix undefined name error for hashlib

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,5 @@
 import hmac
+import hashlib
 from fastapi import FastAPI, Request, HTTPException
 import uvicorn
 from pydantic import BaseModel


### PR DESCRIPTION
Add import statement for hashlib module in `backend/main.py`.

* Import the `hashlib` module at the beginning of the file to resolve the undefined name error for hashlib in the `expected_signature` definition.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shuddl/bookgpt/pull/12?shareId=adfabaf8-756b-4443-8619-98c1712c4f6a).